### PR TITLE
To make it work for newer versions of asyncio.

### DIFF
--- a/python/receive_stream.py
+++ b/python/receive_stream.py
@@ -14,7 +14,7 @@ def is_valid_image(image_bytes):
         print("image invalid")
         return False
 
-async def handle_connection(websocket, path):
+async def handle_connection(websocket):
     while True:
         try:
             message = await websocket.recv()


### PR DESCRIPTION
With the new asyncio implementation of the websockets library, the path argument of connection handlers is "unnecessary since 10.1 and deprecated in 13.0" (read here).